### PR TITLE
Feature/room soft deletes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,3 +22,4 @@ Re-implementation of the back-end in Laravel.
  - When fetching events from a room, it is no longer necessary for the room to be ongoing. Instead, for rooms that haven't yet started, an empty list of events is returned.
  - When a room is deleted, an empty `204 No Content` response is returned instead of returning an id that is no longer in use.
  - When calling `get_room_data`, closed rooms are not shown by default. This can be overridden by including a parameter `return_closed_rooms` with value `true`.
+ - When a player leaving the room renders the room without players, it is now (soft) deleted.

--- a/app/Http/Controllers/RoomController.php
+++ b/app/Http/Controllers/RoomController.php
@@ -263,6 +263,7 @@ class RoomController extends Controller
      * @param Room $room
      * @return Response
      * @throws ValidationException
+     * @throws Exception
      */
     public function leave(Room $room)
     {
@@ -278,6 +279,11 @@ class RoomController extends Controller
         $this->session->player->save();
 
         $room->refresh();
+
+        if ($room->players->isEmpty()) {
+            $room->delete();
+            return new DeletedResponse($room);
+        }
 
         // Since we have indirectly updated the room resource,
         // it makes sense to return it.

--- a/app/Models/Room.php
+++ b/app/Models/Room.php
@@ -14,6 +14,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 /**
  * Class Room
@@ -21,6 +22,7 @@ use Illuminate\Database\Eloquent\Relations\HasOne;
  * @property int $id
  * @property Carbon $created_at
  * @property Carbon $updated_at
+ * @property Carbon $deleted_at
  * @property Carbon $started_at
  * @property Carbon $closed_at
  * @property int $creator_player_id
@@ -45,6 +47,7 @@ use Illuminate\Database\Eloquent\Relations\HasOne;
  * @method static Builder|Room whereClosedAt($value)
  * @method static Builder|Room whereCreatedAt($value)
  * @method static Builder|Room whereCreatorPlayerId($value)
+ * @method static Builder|Room whereDeletedAt($value)
  * @method static Builder|Room whereDescription($value)
  * @method static Builder|Room whereGoalId($value)
  * @method static Builder|Room whereId($value)
@@ -63,7 +66,7 @@ use Illuminate\Database\Eloquent\Relations\HasOne;
  */
 class Room extends Model
 {
-    use SerializesTimestamps;
+    use SerializesTimestamps, SoftDeletes;
 
     protected $dates = [
         'started_at',

--- a/database/migrations/2020_07_22_193355_add_soft_delete_to_rooms.php
+++ b/database/migrations/2020_07_22_193355_add_soft_delete_to_rooms.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddSoftDeleteToRooms extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('rooms', function (Blueprint $table) {
+            $table->softDeletes()->after('updated_at');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('rooms', function (Blueprint $table) {
+            $table->dropSoftDeletes();
+        });
+    }
+}


### PR DESCRIPTION
# Description
Implements [soft deletes](https://laravel.com/docs/7.x/eloquent#soft-deleting) on Rooms and a soft delete now occurs if a Room is left without any Players in it.
<!-- 
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context. This can be helped by linking to any related issue (ex: Fixes #1).
Be as detailed as possible and be sure to indicate how this change will effect downstream users.

Also list any new dependencies/packages that are required for this change.

Example:
=======================
### Added status codes

Requests will now respond with the appropriate status code instead of returning a 200 OK on all requests. Specifically this applies to requests made to: `some_endpoint`
which has a `403 Unauthorized` response, as well as a `401 Bad Request`.
=======================
-->

# Type of change

<!-- Please select options that are relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] New dependencies/packages

# Testing

<!-- Describe the tests that you ran to verify your changes -->

- [ ] I have created automated tests for any new features
- [x] All automated tests pass
- [x] I have performed manual tests


# Checklist:

<!-- Please make sure the following have been performed. -->
<!-- If they have not yet been performed, leave them unchecked (and/or) title your PR with "WIP: ". -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code (not really applicable since it is a very small and easy to follow change)
- [x] I have [documented any new API endpoints in the postman collection](https://learning.postman.com/docs/postman/api-documentation/documenting-your-api/#documenting-an-existing-collection)
- [x] I have [added examples in postman](https://blog.postman.com/2017/05/17/mock-responses-in-postman-by-using-examples/) for all status codes.
- [x] I have made corresponding changes to the README (if required)
- [x] My changes generate no new warnings and do not break existing endpoints

# Questions / Discussion

<!-- Any questions you are still wondering about or discussions to be had about the changes.
You can also include specific areas/files you would like reviewed or commented on. -->